### PR TITLE
Implement userService through loginServlet to create authenticated experience.

### DIFF
--- a/launchpod/angular-launchpod/backend/src/main/java/com/google/launchpod/data/LoginStatus.java
+++ b/launchpod/angular-launchpod/backend/src/main/java/com/google/launchpod/data/LoginStatus.java
@@ -1,0 +1,26 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.launchpod.data;
+
+/** An item on a comment list. */
+public final class LoginStatus {
+  public final boolean isLoggedIn;
+  public final String message;
+
+  public LoginStatus(boolean isLoggedIn, String message) {
+    this.isLoggedIn = isLoggedIn;
+    this.message = message;
+  }
+}

--- a/launchpod/angular-launchpod/backend/src/main/java/com/google/launchpod/servlets/LoginServlet.java
+++ b/launchpod/angular-launchpod/backend/src/main/java/com/google/launchpod/servlets/LoginServlet.java
@@ -1,0 +1,54 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.launchpod.servlets;
+
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.gson.Gson;
+import com.google.launchpod.data.LoginStatus;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/login-status")
+public class LoginServlet extends HttpServlet {
+  private static final Gson GSON = new Gson();
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    response.setContentType("application/json");
+
+    UserService userService = UserServiceFactory.getUserService();
+    String urlToRedirectTo = "/index.html";
+    if (userService.isUserLoggedIn()) {
+      String userEmail = userService.getCurrentUser().getEmail();
+      String logoutUrl = userService.createLogoutURL(urlToRedirectTo);
+
+      String loginMessage = "<p>Logged in as " + userEmail + ". <a href=\"" + logoutUrl + "\">Logout</a>.</p>";
+      LoginStatus loginStatus = new LoginStatus(true, loginMessage);
+
+      response.getWriter().println(GSON.toJson(loginStatus));
+    } else {
+      String loginUrl = userService.createLoginURL(urlToRedirectTo);
+
+      String loginMessage = loginUrl;
+      LoginStatus loginStatus = new LoginStatus(false, loginMessage);
+
+      response.getWriter().println(GSON.toJson(loginStatus));
+    }
+  }
+}

--- a/launchpod/angular-launchpod/backend/src/test/java/com/google/launchpod/LoginServletTest.java
+++ b/launchpod/angular-launchpod/backend/src/test/java/com/google/launchpod/LoginServletTest.java
@@ -1,0 +1,179 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.launchpod;
+
+import static com.google.appengine.api.datastore.FetchOptions.Builder.withLimit;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.security.interfaces.DSAKey;
+
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.gson.Gson;
+import com.google.gson.JsonParser;
+import com.google.launchpod.data.LoginStatus;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import com.google.launchpod.servlets.LoginServlet;
+import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Runs unit tests for the LoginServlet that contains doGet() method.
+ */
+@RunWith(JUnit4.class)
+public class LoginServletTest extends Mockito {
+
+  @InjectMocks
+  private LoginServlet servlet = new LoginServlet();
+
+  @Mock
+  HttpServletRequest request;
+
+  @Mock
+  HttpServletResponse response;
+
+  @Rule // JUnit 4 uses Rules for testing specific messages
+  public ExpectedException thrown = ExpectedException.none();
+
+  private final LocalServiceTestHelper helper = new LocalServiceTestHelper(new LocalUserServiceTestConfig());
+
+  private static final Gson GSON = new Gson();
+  JsonParser parser = new JsonParser();
+
+  private static final String EMAIL = "email";
+
+  private static final String TEST_EMAIL = "123@abc.com";
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    helper.setUp();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  /**
+   * Asserts that doPost() gets the user's correct status when logged in.
+   */
+  @Test
+  public void doGet_GetsCorrectStatusLoggedIn() throws IOException {
+    helper.setEnvIsLoggedIn(true).setEnvEmail(TEST_EMAIL).setEnvAuthDomain("localhost");
+    UserService userService = UserServiceFactory.getUserService();
+
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(writer);
+
+    servlet.doGet(request, response);
+
+    String urlToRedirectToAfterUserLogsOut = "/index.html";
+    String logoutUrl = userService.createLogoutURL(urlToRedirectToAfterUserLogsOut);
+    String loginMessage = "<p>Logged in as " + TEST_EMAIL + ". <a href=\"" + logoutUrl + "\">Logout</a>.</p>";
+    LoginStatus loginStatus = new LoginStatus(true, loginMessage);
+    verify(response).setContentType("application/json");
+    assertEquals(loginStatus.isLoggedIn, GSON.fromJson(stringWriter.toString(), LoginStatus.class).isLoggedIn);
+  }
+
+  /**
+   * Asserts that doPost() gets the user's email and successfully sends
+   * a corresponding loginStatus object as the response.
+   */
+  @Test
+  public void doGet_GetsCorrectMessageLoggedIn() throws IOException {
+    helper.setEnvIsLoggedIn(true).setEnvEmail(TEST_EMAIL).setEnvAuthDomain("localhost");
+    UserService userService = UserServiceFactory.getUserService();
+
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(writer);
+
+    servlet.doGet(request, response);
+
+    String urlToRedirectToAfterUserLogsOut = "/index.html";
+    String logoutUrl = userService.createLogoutURL(urlToRedirectToAfterUserLogsOut);
+    String loginMessage = "<p>Logged in as " + TEST_EMAIL + ". <a href=\"" + logoutUrl + "\">Logout</a>.</p>";
+    LoginStatus loginStatus = new LoginStatus(true, loginMessage);
+    verify(response).setContentType("application/json");
+    assertEquals(loginStatus.message, GSON.fromJson(stringWriter.toString(), LoginStatus.class).message);
+  }
+
+  /**
+   * Asserts that doPost() gets the user's correct status when logged out.
+   */
+  @Test
+  public void doGet_GetsCorrectStatusLoggedOut() throws IOException {
+    helper.setEnvIsLoggedIn(false);
+    UserService userService = UserServiceFactory.getUserService();
+
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(writer);
+
+    servlet.doGet(request, response);
+
+    String urlToRedirectToAfterUserLogsOut = "/index.html";
+    String loginUrl = userService.createLoginURL(urlToRedirectToAfterUserLogsOut);
+    String loginMessage = loginUrl;
+    LoginStatus loginStatus = new LoginStatus(false, loginMessage);
+    verify(response).setContentType("application/json");
+    assertEquals(loginStatus.isLoggedIn, GSON.fromJson(stringWriter.toString(), LoginStatus.class).isLoggedIn);
+  }
+
+  /**
+   * Asserts that doPost() successfully sends a login url as the
+   * response when the user is not logged in.
+   */
+  @Test
+  public void doGet_GetsCorrectMessageLoggedOut() throws IOException {
+    helper.setEnvIsLoggedIn(false);
+    UserService userService = UserServiceFactory.getUserService();
+
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(writer);
+
+    servlet.doGet(request, response);
+
+    String urlToRedirectToAfterUserLogsOut = "/index.html";
+    String loginUrl = userService.createLoginURL(urlToRedirectToAfterUserLogsOut);
+    String loginMessage = loginUrl;
+    LoginStatus loginStatus = new LoginStatus(false, loginMessage);
+    verify(response, atLeast(1)).setContentType("application/json");
+    assertEquals(loginStatus.message, GSON.fromJson(stringWriter.toString(), LoginStatus.class).message);
+  }
+}

--- a/launchpod/angular-launchpod/backend/src/test/java/com/google/launchpod/LoginServletTest.java
+++ b/launchpod/angular-launchpod/backend/src/test/java/com/google/launchpod/LoginServletTest.java
@@ -70,7 +70,6 @@ public class LoginServletTest extends Mockito {
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper(new LocalUserServiceTestConfig());
 
   private static final Gson GSON = new Gson();
-  JsonParser parser = new JsonParser();
 
   private static final String EMAIL = "email";
 

--- a/launchpod/angular-launchpod/src/app/form-handler.service.ts
+++ b/launchpod/angular-launchpod/src/app/form-handler.service.ts
@@ -10,10 +10,10 @@ const LOGIN_URL = '/login-status';
 })
 export class FormHandlerService {
 
-  private feedValueSubject = new BehaviorSubject<string>("feedValue");
+  private feedValueSubject = new BehaviorSubject<string>("Loading URL...");
   feedValue = this.feedValueSubject.asObservable();
 
-  private loginLinkSubject = new BehaviorSubject<string>("loginLink");
+  private loginLinkSubject = new BehaviorSubject<string>("Loading...");
   loginLink = this.loginLinkSubject.asObservable();
 
   constructor(private http: HttpClient) {}


### PR DESCRIPTION
This PR directly relates to frontend changes on PR https://github.com/googleinterns/step18-2020/pull/43 and contains the following:
- LoginStatus Object (indicates if the user is logged in so the frontend can decide whether or not to open the [login dialog](https://screenshot.googleplex.com/NypgJTxfTZR.png))
- LoginServlet with doGet() method that returns a LoginStatus Object
- Unit tests for the new LoginServlet.
- User Logged In: https://screenshot.googleplex.com/m2Ka5yJ08Un.png
- User Logged Out: https://screenshot.googleplex.com/WtcK5hoPrD0.png
- TODO: Add itunes:owner tag to RSS Feeds https://github.com/googleinterns/step18-2020/issues/35
- TODO: Display feeds associated with user email on "My Feeds page" on the frontend https://github.com/googleinterns/step18-2020/issues/34